### PR TITLE
Fix stub tests

### DIFF
--- a/subworkflows/save_run_details.nf
+++ b/subworkflows/save_run_details.nf
@@ -3,6 +3,7 @@ process WRITE_VERSION_INFO {
     label 'process_low_constant'
     executor 'local'
     publishDir "${params.result_dir}", failOnError: true, mode: 'copy'
+    cache false
 
     input:
         val workflow_var_names

--- a/test-resources/test-cascadia.config
+++ b/test-resources/test-cascadia.config
@@ -12,7 +12,7 @@
 params {
 
     // the data to be processed.
-	
+
 	// note: files and directories may specify a local file or a PanoramaWeb WebDAV directory/file
 	// Example local file:
 	//    spectral_library = '/path/to/file.dlib'
@@ -94,9 +94,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/test-resources/test-diann-multi-batch.config
+++ b/test-resources/test-diann-multi-batch.config
@@ -95,9 +95,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/test-resources/test-diann-pdc.config
+++ b/test-resources/test-diann-pdc.config
@@ -13,7 +13,7 @@ params {
 
     // the search engine to use
     search_engine = 'diann'
-    
+
     pdc.study_id = 'PDC000504'
     pdc.n_raw_files = 2
 
@@ -36,9 +36,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/test-resources/test-diann.config
+++ b/test-resources/test-diann.config
@@ -12,7 +12,7 @@
 params {
 
     // the data to be processed.
-	
+
 	// note: files and directories may specify a local file or a PanoramaWeb WebDAV directory/file
 	// Example local file:
 	//    spectral_library = '/path/to/file.dlib'
@@ -94,9 +94,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/test-resources/test-encyclopedia-narrow-gpf.config
+++ b/test-resources/test-encyclopedia-narrow-gpf.config
@@ -12,7 +12,7 @@
 params {
 
     // the data to be processed.
-	
+
 	// note: files and directories may specify a local file or a PanoramaWeb WebDAV directory/file
 	// Example local file:
 	//    spectral_library = '/path/to/file.dlib'
@@ -94,9 +94,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/test-resources/test-encyclopedia-wide-only.config
+++ b/test-resources/test-encyclopedia-wide-only.config
@@ -12,7 +12,7 @@
 params {
 
     // the data to be processed.
-	
+
 	// note: files and directories may specify a local file or a PanoramaWeb WebDAV directory/file
 	// Example local file:
 	//    spectral_library = '/path/to/file.dlib'
@@ -94,9 +94,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/test-resources/test-msconvert-only-local.config
+++ b/test-resources/test-msconvert-only-local.config
@@ -10,14 +10,14 @@
 
 // params will need changed per workflow run
 params {
-    
+
     chromatogram_library_spectra_dir = 'test-resources/narrow-window'
     quant_spectra_dir = 'test-resources/wide-window'
 
 	// options for msconvert
     msconvert.do_demultiplex = true;          // whether or not to demultiplex with msconvert
     msconvert.do_simasspectra = true;         // whether or not to do simAsSpectra with msconvert
-    
+
     msconvert_only = true
 }
 
@@ -29,9 +29,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/test-resources/test-msconvert-only-pdc.config
+++ b/test-resources/test-msconvert-only-pdc.config
@@ -10,14 +10,14 @@
 
 // params will need changed per workflow run
 params {
-    
+
     pdc.study_id = 'PDC000504'
     pdc.n_raw_files = 2
 
 	// options for msconvert
     msconvert.do_demultiplex = false;          // whether or not to demultiplex with msconvert
     msconvert.do_simasspectra = true;         // whether or not to do simAsSpectra with msconvert
-    
+
     msconvert_only = true
 }
 
@@ -29,9 +29,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/test-resources/test-skip-dia-search.config
+++ b/test-resources/test-skip-dia-search.config
@@ -41,9 +41,9 @@ profiles {
     // your system resources (that you are willing to devote to running
     // workflow jobs).
     standard {
-        params.max_memory = '8.GB'
-        params.max_cpus = 4
-        params.max_time = '1.h'
+        process {
+            resourceLimits = [cpus: 2, memory: '4.GB', time: '1.h']
+        }
 
         params.mzml_cache_directory = './mzml_cache'
         params.panorama_cache_directory = './raw_cache'

--- a/workflows/carafe.nf
+++ b/workflows/carafe.nf
@@ -24,7 +24,7 @@ workflow carafe {
         if (params.carafe.carafe_fasta == null){
             carafe_fasta = input_fasta
         } else {
-            get_carafe_fasta(params.carafe.fasta, aws_secret_id)
+            get_carafe_fasta(params.carafe.carafe_fasta, aws_secret_id)
             carafe_fasta = get_carafe_fasta.out.file
         }
         if (params.carafe.diann_fasta == null){


### PR DESCRIPTION
* Update GitHub action tests to use `resourceLimits` directive
* Fix typo in `params.carafe.fasta` -> `params.carafe.carafe_fasta`
* Get rid of 'Cannot serialize context map.' warning by not caching `WRITE_VERSION_INFO` process.